### PR TITLE
Add engine environment flags 'HORS_ENGINE'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ For now, `hors` has been tested with the following platforms:
 # Usage
 ```shell
 USAGE:
-    hors [FLAGS] [OPTIONS] <query>
+    hors [FLAGS] [OPTIONS] [query]...
 
 ARGS:
-    <query>
+    <query>...
 
 FLAGS:
     -a, --all              display the full text of answer.
@@ -40,7 +40,7 @@ FLAGS:
 
 OPTIONS:
     -e, --engine <engine>                    select middle search engine, currently support `bing`, `google` and
-                                             `duckduckgo`. [default: duckduckgo]
+                                             `duckduckgo`. [env: HORS_ENGINE=]  [default: duckduckgo]
     -n, --number-answers <number-answers>    number of answers to return. [default: 1]
 ```
 

--- a/src/bin/hors.rs
+++ b/src/bin/hors.rs
@@ -23,6 +23,7 @@ struct Opts {
         short,
         long,
         default_value = "duckduckgo",
+        env = "HORS_ENGINE",
         about("select middle search engine, currently support `bing`, `google` and `duckduckgo`.")
     )]
     engine: String,


### PR DESCRIPTION
The only consistent change that I'd think of doing to the program (configuration-wise) is the default engine - to avoid passing `-e` every time, so I added env var support with the `HORS_ENGINE` variable.

Example (I found a query that was different for duckduckgo vs google):
```bash
dzervas hors> ./target/debug/hors -e google rust vec string join chinese version wow
- Answer from https://stackoverflow.com/questions/7488206
SELECT id, CONCAT(firstName, ' ', lastName) AS fullName FROM table

dzervas hors> ./target/debug/hors -e duckduckgo rust vec string join chinese version wow
Search for target link failed: Parse("Can\'t find search result...")

dzervas hors> HORS_ENGINE=google ./target/debug/hors rust vec string join chinese version wow
- Answer from https://stackoverflow.com/questions/7488206
SELECT id, CONCAT(firstName, ' ', lastName) AS fullName FROM table
```