### PR TITLE
Replaced the `dirs` dependency with the `directories`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
+name = "directories"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -543,7 +543,7 @@ version = "0.6.4"
 dependencies = [
  "bincode 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 3.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "directories 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2079,7 +2079,7 @@ dependencies = [
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum derefable 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e519abf1289075763071c981958e89948b079fc54962617a0e6413d9ce44cbe7"
-"checksum dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+"checksum directories 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
 "checksum dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.7.3"
 log = "0.4.11"
 serde = { version = "1.0.114", features = ["derive"] }
 bincode = "1.3.1"
-dirs = "3.0.1"
+directories = "3.0.1"
 url = "2.1.1"
 
 [dev-dependencies]

--- a/src/answer/records.rs
+++ b/src/answer/records.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use bincode::{deserialize_from, serialize_into};
-use dirs::cache_dir;
+use directories::BaseDirs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{create_dir_all, File, OpenOptions};
@@ -59,8 +59,9 @@ impl AnswerRecordsCache {
     /// Return the instance of AnswerRecordsCache.  Error will be returned if
     /// loading local cache file failed.
     pub fn load() -> Result<AnswerRecordsCache> {
-        if let Some(dir) = cache_dir() {
+        if let Some(base_dirs) = BaseDirs::new() {
             // just create cache file if not existed, and deserialize it.
+            let dir = base_dirs.cache_dir().to_path_buf();
             let cache_file: PathBuf = AnswerRecordsCache::create_file_if_not_existed(&dir)?;
             let f = File::open(cache_file)?;
             let answer_records: AnswerRecordsCache = deserialize_from(f)?;
@@ -129,7 +130,8 @@ impl AnswerRecordsCache {
         if MAX_SIZE < self.0.len() {
             // TODO: truncate it to have size MAX_SIZE
         }
-        if let Some(dir) = cache_dir() {
+        if let Some(base_dirs) = BaseDirs::new() {
+            let dir = base_dirs.cache_dir();
             let cache_path: PathBuf = dir.join("hors").join("answers");
             let f = OpenOptions::new()
                 .write(true)


### PR DESCRIPTION
Since only the cache directory was used, the `dirs` crate
README suggests to use `directories` crate (https://github.com/dirs-dev/dirs-rs#features).