### PR TITLE
Fixed the `redundant_closure` clippy warning

### DIFF
--- a/src/engine/bing.rs
+++ b/src/engine/bing.rs
@@ -26,7 +26,7 @@ impl Engine for Bing {
         let links: Vec<String> = target_elements
             .filter_map(|node| node.attr("href"))
             .filter(|link| link.contains("stackoverflow.com"))
-            .map(|link| String::from(link))
+            .map(String::from)
             .collect();
 
         debug!("Links extract from bing: {:?}", links);

--- a/src/engine/google.rs
+++ b/src/engine/google.rs
@@ -30,7 +30,7 @@ impl Engine for Google {
         let target_elements = doc.find(Class("r").child(Name("a")));
         let links: Vec<String> = target_elements
             .filter_map(|node| node.attr("href"))
-            .map(|link| String::from(link))
+            .map(String::from)
             .collect();
 
         debug!("Links extract from google: {:?}", links);


### PR DESCRIPTION
Relevant link: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure