### PR TITLE
Concurrent precious

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ clap = "3.0.0-beta.2"
 syntect = "4.4.0"
 base64 = "0.12.3"
 reqwest = { version="0.10.8", features=["json", "socks", "cookies", "rustls-tls", "gzip"], default-features=false }
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "0.2", features = ["macros", "sync", "rt-core"] }
 select = "0.5.0"
 rand = "0.7.3"
 log = "0.4.11"

--- a/src/answer/crawler.rs
+++ b/src/answer/crawler.rs
@@ -1,3 +1,5 @@
+//! Crawler for fetching so page.
+
 use super::records::AnswerRecordsCache;
 use crate::config::Config;
 use crate::utils::random_agent;

--- a/src/answer/crawler.rs
+++ b/src/answer/crawler.rs
@@ -1,0 +1,175 @@
+use super::records::AnswerRecordsCache;
+use crate::config::Config;
+use crate::utils::random_agent;
+use crate::Result;
+use reqwest::{Client, Response};
+use std::process;
+use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
+
+pub struct PageCrawler {
+    links: Vec<String>,
+    conf: Config,
+    records_cache: AnswerRecordsCache,
+    client: Client,
+    msg_sender: Sender<CrawlerMsg>,
+}
+
+impl PageCrawler {
+    pub fn new(
+        links: Vec<String>,
+        conf: Config,
+        records_cache: AnswerRecordsCache,
+        client: Client,
+        msg_sender: Sender<CrawlerMsg>,
+    ) -> PageCrawler {
+        PageCrawler {
+            links,
+            conf,
+            records_cache,
+            client,
+            msg_sender,
+        }
+    }
+
+    pub fn fetch(mut self) {
+        tokio::spawn(async move {
+            let mut links_iter = self.links.into_iter();
+            let mut tasks = vec![];
+            for _ in 0..self.conf.numbers() {
+                let mut sender = self.msg_sender.clone();
+                let next_link = links_iter.next();
+                match next_link {
+                    Some(link) => {
+                        // the given links may contains the url doesn't contains `question`
+                        // tag, so it's not a question, just deal with nothing to it.
+                        if !link.contains("question") {
+                            continue;
+                        }
+
+                        // try to fetch page from cache first.
+                        let page_from_cache: Option<&String> = self.records_cache.get(&link);
+                        match page_from_cache {
+                            // When we can get answer from cache, just send the result back to upload task.
+                            Some(page) => {
+                                if sender
+                                    .send(CrawlerMsg::Data(CrawledData::new(
+                                        format!("- Answer from {}", &link),
+                                        link,
+                                        page.into(),
+                                    )))
+                                    .await
+                                    .is_err()
+                                {
+                                    error!(
+                                            "Receiver is dropped un-expectly, if you see this message, please fire an issue"
+                                        );
+                                    process::exit(1);
+                                }
+                                continue;
+                            }
+                            None => {
+                                let work_client: Client = self.client.clone();
+                                // spawn task only we can't find page from cache.
+                                let single_fetcher: JoinHandle<Result<CrawledData>> = tokio::spawn(
+                                    async move {
+                                        let page: String = get_page(&link, &work_client).await?;
+                                        let crawled_data = CrawledData::new(
+                                            format!("- Answer from {}", &link),
+                                            link.clone(),
+                                            page.clone(),
+                                        );
+                                        if sender
+                                            .send(CrawlerMsg::Data(crawled_data.clone()))
+                                            .await
+                                            .is_err()
+                                        {
+                                            error!(
+                                                "Receiver is dropped un-expectly, if you see this message, please fire an issue"
+                                            );
+                                            process::exit(1);
+                                        }
+                                        return Ok(crawled_data);
+                                    },
+                                );
+                                tasks.push(single_fetcher);
+                            }
+                        }
+                    }
+                    None => break,
+                }
+            }
+
+            for t in tasks {
+                // fetch result from sub tasks and save them to cache.
+                if let Ok(crawled_result) = t.await {
+                    if let Ok(crawled_data) = crawled_result {
+                        let (link, page) = crawled_data.into_cache_item();
+                        self.records_cache.put(link, page);
+                    }
+                }
+            }
+
+            // when hors gets what we wanted answer, save it for next time using.
+            if let Err(err) = self.records_cache.save() {
+                warn!(
+                    "Can't save cache into local directory, error msg: {:?}",
+                    err
+                );
+            }
+
+            if self.msg_sender.send(CrawlerMsg::Done).await.is_err() {
+                error!(
+                    "Receiver is dropped un-expectly, if you see this message, please fire an issue"
+                );
+                process::exit(1);
+            }
+        });
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CrawlerMsg {
+    Data(CrawledData),
+    Done,
+}
+
+#[derive(Debug, Clone)]
+pub struct CrawledData {
+    link: String,
+    title: String,
+    page: String,
+}
+
+impl CrawledData {
+    pub fn new(title: String, link: String, page: String) -> CrawledData {
+        CrawledData { link, title, page }
+    }
+
+    pub fn get_title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn get_link(&self) -> &str {
+        &self.title
+    }
+
+    pub fn get_page(&self) -> &str {
+        &self.page
+    }
+
+    pub fn into_cache_item(self) -> (String, String) {
+        (self.link, self.page)
+    }
+}
+
+async fn get_page(link: &str, client: &Client) -> Result<String> {
+    let resp: Response = client
+        .get(link)
+        .header(reqwest::header::USER_AGENT, random_agent())
+        .send()
+        .await?;
+    debug!("Response status from stackoverflow: {:?}", resp);
+    let page: String = resp.text().await?;
+    Ok(page)
+}

--- a/src/answer/crawler.rs
+++ b/src/answer/crawler.rs
@@ -21,10 +21,20 @@ impl PageCrawler {
     pub fn new(
         links: Vec<String>,
         conf: Config,
-        records_cache: AnswerRecordsCache,
         client: Client,
         msg_sender: Sender<CrawlerMsg>,
     ) -> PageCrawler {
+        debug!("Try to load cache from local cache file.");
+        let load_result: Result<AnswerRecordsCache> = AnswerRecordsCache::load();
+        let records_cache: AnswerRecordsCache = match load_result {
+            Ok(cache) => cache,
+            Err(err) => {
+                warn!("Can't load cache from local cache file, errmsg {:?}", err);
+                AnswerRecordsCache::load_empty()
+            }
+        };
+        debug!("Load cache complete.");
+
         PageCrawler {
             links,
             conf,

--- a/src/answer/mod.rs
+++ b/src/answer/mod.rs
@@ -1,5 +1,5 @@
 mod colorize;
+mod crawler;
 mod precious;
 mod records;
-mod crawler;
 pub use precious::{get_answers, get_answers_with_client, SPLITTER};

--- a/src/answer/mod.rs
+++ b/src/answer/mod.rs
@@ -1,4 +1,5 @@
 mod colorize;
 mod precious;
 mod records;
+mod crawler;
 pub use precious::{get_answers, get_answers_with_client, SPLITTER};

--- a/src/answer/precious.rs
+++ b/src/answer/precious.rs
@@ -64,7 +64,7 @@ pub async fn get_answers(links: &[String], conf: Config) -> Result<String> {
 /// let links: Vec<String> = vec![
 ///     String::from("https://stackoverflow.com/questions/7771011/how-to-parse-data-in-json")
 /// ];
-/// let answers: String = hors::get_answers_with_client(&links, conf, &client).await.unwrap();
+/// let answers: String = hors::get_answers_with_client(&links, conf, client).await.unwrap();
 /// assert!(
 ///     answers.contains(
 ///         r#"data = json.loads('{"one" : "1", "two" : "2", "three" : "3"}')"#

--- a/src/bin/hors.rs
+++ b/src/bin/hors.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
 
     let conf: Config = init_config(&opts);
     debug!("User config: {:?}", conf);
-    let answers: String = hors::get_answers_with_client(&target_links, conf, &client)
+    let answers: String = hors::get_answers_with_client(&target_links, conf, client)
         .await
         .unwrap_or_else(|err| {
             eprintln!("Hors is running to error: {}", err);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use std::str::FromStr;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 /// The results output options.
 pub enum OutputOption {
     /// Only output links.
@@ -25,7 +25,7 @@ pub enum SearchEngine {
     StackOverflow,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 /// The user config information is integrated here.
 pub struct Config {
     /// Terminal output options.

--- a/tests/test_answer.rs
+++ b/tests/test_answer.rs
@@ -13,7 +13,7 @@ async fn test_get_answers_with_links_only() {
         .cookie_store(true)
         .build()
         .unwrap();
-    let answers: String = get_answers_with_client(&links, conf, &client)
+    let answers: String = get_answers_with_client(&links, conf, client)
         .await
         .expect("Get answer through stackoverflow should success")
         .split(SPLITTER)
@@ -36,7 +36,7 @@ async fn test_get_answers_with_detailed_option() {
         .cookie_store(true)
         .build()
         .unwrap();
-    let answers: String = get_answers_with_client(&links, conf, &client)
+    let answers: String = get_answers_with_client(&links, conf, client)
         .await
         .expect("Get answer through stackoverflow should success")
         .split(SPLITTER)
@@ -64,7 +64,7 @@ async fn test_get_answers_with_instruction() {
         .cookie_store(true)
         .build()
         .unwrap();
-    let answers: String = get_answers_with_client(&links, conf, &client)
+    let answers: String = get_answers_with_client(&links, conf, client)
         .await
         .expect("Get answer through stackoverflow should success")
         .split(SPLITTER)


### PR DESCRIPTION
Closes: #97 

Implement concurrent precious feature, it can speed up our answer fetching progress when we want to fetch more than one answer. (like two)